### PR TITLE
Change copyright date to be inline with in-game lore

### DIFF
--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -86,7 +86,7 @@ export function Footer() {
           <br />
           <Typography variant="body2" color="textSecondary" align="center">
             {"Copyright © "}
-            SC Market {new Date().getFullYear()}
+            SC Market {new Date().getFullYear() + 930}
             {"."}
             <br />
             {


### PR DESCRIPTION
I really like using the site but I get disconnected from my in-game character when using the store and seeing the current year on the footer. I believe that changing that would give people an enhanced store experience and keep them connected to the game and its community.